### PR TITLE
feat: add variables to define helm repository username and password

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ No modules.
 | <a name="input_helm_cleanup_on_fail"></a> [helm\_cleanup\_on\_fail](#input\_helm\_cleanup\_on\_fail) | Allow deletion of new resources created in this upgrade when upgrade fails. Defaults to false. | `bool` | `false` | no |
 | <a name="input_helm_create_namespace"></a> [helm\_create\_namespace](#input\_helm\_create\_namespace) | Create the namespace if it does not yet exist | `bool` | `true` | no |
 | <a name="input_helm_release_name"></a> [helm\_release\_name](#input\_helm\_release\_name) | Helm release name | `string` | `"argocd"` | no |
+| <a name="input_helm_repo_password"></a> [helm\_repo\_password](#input\_helm\_repo\_password) | Helm repository password | `string` | `null` | no |
+| <a name="input_helm_repo_username"></a> [helm\_repo\_username](#input\_helm\_repo\_username) | Helm repository username | `string` | `null` | no |
 | <a name="input_helm_repo_url"></a> [helm\_repo\_url](#input\_helm\_repo\_url) | Helm repository | `string` | `"https://argoproj.github.io/argo-helm"` | no |
 | <a name="input_helm_timeout"></a> [helm\_timeout](#input\_helm\_timeout) | Time in seconds to wait for any individual kubernetes operation (like Jobs for hooks). Defaults to 300 seconds. | `number` | `300` | no |
 | <a name="input_helm_wait"></a> [helm\_wait](#input\_helm\_wait) | Will wait until all resources are in a ready state before marking the release as successful. It will wait for as long as timeout. Defaults to true. | `bool` | `true` | no |

--- a/helm.tf
+++ b/helm.tf
@@ -1,15 +1,17 @@
 resource "helm_release" "this" {
-  count            = var.enabled && !var.self_managed && !var.argo_application_enabled ? 1 : 0
-  chart            = var.helm_chart_name
-  create_namespace = var.helm_create_namespace
-  namespace        = var.k8s_namespace
-  name             = var.helm_release_name
-  version          = var.helm_chart_version
-  repository       = var.helm_repo_url
-  wait             = var.helm_wait
-  timeout          = var.helm_timeout
-  cleanup_on_fail  = var.helm_cleanup_on_fail
-  atomic           = var.helm_atomic
+  count               = var.enabled && !var.self_managed && !var.argo_application_enabled ? 1 : 0
+  chart               = var.helm_chart_name
+  create_namespace    = var.helm_create_namespace
+  namespace           = var.k8s_namespace
+  name                = var.helm_release_name
+  version             = var.helm_chart_version
+  repository          = var.helm_repo_url
+  repository_username = var.helm_repo_username
+  repository_password = var.helm_repo_password  
+  wait                = var.helm_wait
+  timeout             = var.helm_timeout
+  cleanup_on_fail     = var.helm_cleanup_on_fail
+  atomic              = var.helm_atomic
 
   values = [
     var.values
@@ -25,13 +27,16 @@ resource "helm_release" "this" {
 }
 
 resource "helm_release" "self_managed" {
-  count            = var.enabled && var.self_managed && !var.argo_application_enabled ? 1 : 0
-  chart            = var.helm_chart_name
-  create_namespace = var.helm_create_namespace
-  namespace        = var.k8s_namespace
-  name             = var.helm_release_name
-  version          = var.helm_chart_version
-  repository       = var.helm_repo_url
+  count               = var.enabled && var.self_managed && !var.argo_application_enabled ? 1 : 0
+  chart               = var.helm_chart_name
+  create_namespace    = var.helm_create_namespace
+  namespace           = var.k8s_namespace
+  name                = var.helm_release_name
+  version             = var.helm_chart_version
+  repository          = var.helm_repo_url
+  repository_username = var.helm_repo_username
+  repository_password = var.helm_repo_password
+
   wait             = var.helm_wait
   timeout          = var.helm_timeout
   cleanup_on_fail  = var.helm_cleanup_on_fail

--- a/variables.tf
+++ b/variables.tf
@@ -32,6 +32,20 @@ variable "helm_release_name" {
   description = "Helm release name"
 }
 
+variable "helm_repo_username" {
+  type        = string
+  default     = null
+  sensitive   = true
+  description = "Helm repository username"
+}
+
+variable "helm_repo_password" {
+  type        = string
+  default     = null
+  sensitive   = true
+  description = "Helm repository password"
+}
+
 variable "helm_repo_url" {
   type        = string
   default     = "https://argoproj.github.io/argo-helm"


### PR DESCRIPTION
I have all my helm charts in a private repository and use this terraform module to deploy them.

helm terraform provider does not use credentials for basic auth when I add them via helm_repo_url, so I added the handling via variables helm_repo_username and helm_repo_password with that it works.

I give them as default value null, so that they are optional and not should become a breaking change for other users.